### PR TITLE
Enrico devel

### DIFF
--- a/go_to_location/src/go_to_location_client_node.cpp
+++ b/go_to_location/src/go_to_location_client_node.cpp
@@ -54,6 +54,7 @@ int main(int argc, char **argv)
   manipulation_msgs::GoToGoal goto_goal;
   goto_goal.location_names.push_back("home");
   goto_goal.to_loc_ctrl_id = "trajectory_tracking";
+  goto_goal.job_exec_name = "go_to";
   goto_goal.tool_id = "fake_gripper";
   goto_goal.property_exec_id = "open";
 

--- a/go_to_location/src/go_to_location_server_node.cpp
+++ b/go_to_location/src/go_to_location_server_node.cpp
@@ -41,7 +41,7 @@ int main(int argc, char **argv)
   spinner.start();
 
   ROS_INFO("Creating GoToLocation server...");
-  manipulation::GoToLocation go_to(nh,pnh,"go_to");
+  manipulation::GoToLocation go_to(nh,pnh);
 
   ros::ServiceClient ps_client = nh.serviceClient<moveit_msgs::GetPlanningScene>("/get_planning_scene");
   ps_client.waitForExistence();

--- a/inbound_pick/src/inbound_pick_client_node.cpp
+++ b/inbound_pick/src/inbound_pick_client_node.cpp
@@ -57,6 +57,7 @@ int main(int argc, char **argv)
   //pick_goal.object_types.push_back("squadra_grande");
 
   pick_goal.to_loc_ctrl_id = "trajectory_tracking";
+  pick_goal.job_exec_name = "pick";
   pick_goal.tool_id = "fake_gripper";
   pick_goal.property_exec_id = "close";
 

--- a/inbound_pick/src/inbound_pick_server_node.cpp
+++ b/inbound_pick/src/inbound_pick_server_node.cpp
@@ -41,7 +41,7 @@ int main(int argc, char **argv)
   spinner.start();
 
   ROS_INFO("Creating PickOject server...");
-  manipulation::PickObjects pick(nh,pnh,"pick");
+  manipulation::PickObjects pick(nh,pnh);
 
   ros::ServiceClient ps_client = nh.serviceClient<moveit_msgs::GetPlanningScene>("/get_planning_scene");
   ps_client.waitForExistence();

--- a/manipulation_msgs/action/GoTo.action
+++ b/manipulation_msgs/action/GoTo.action
@@ -2,7 +2,9 @@
 string[] location_names
 #Controller type used during the execution of the movement
 string to_loc_ctrl_id
-#Tool referance to execute the skill
+#name of the tool client topic
+string job_exec_name
+#Tool name to execute the skill
 string tool_id
 #Property associated to the use of the tool
 string property_exec_id

--- a/manipulation_msgs/action/PickObjects.action
+++ b/manipulation_msgs/action/PickObjects.action
@@ -14,7 +14,9 @@ string approach_loc_ctrl_id
 string to_loc_ctrl_id
 #Controller type used during the execution of the movement to leave the picking location
 string leave_loc_ctrl_id
-#Tool referance to execute the skill
+#name of the tool client topic
+string job_exec_name
+#Tool name to execute the skill
 string tool_id
 #Property associated to the use of the tool before picking execution
 string property_pre_exec_id

--- a/manipulation_msgs/action/PlaceObjects.action
+++ b/manipulation_msgs/action/PlaceObjects.action
@@ -9,7 +9,9 @@ string approach_loc_ctrl_id
 string to_loc_ctrl_id
 #Controller type used during the execution of the movement to leave the placing location
 string leave_loc_ctrl_id
-#Tool referance ti be used to execute the skill
+#name of the tool client topic
+string job_exec_name
+#Tool name to execute the skill
 string tool_id
 #Property associated to the use of the tool before placing execution
 string property_pre_exec_id

--- a/manipulation_utils/include/manipulation_utils/go_to_location.h
+++ b/manipulation_utils/include/manipulation_utils/go_to_location.h
@@ -44,8 +44,7 @@ protected:
 
 public:
   GoToLocation( const ros::NodeHandle& nh,
-                const ros::NodeHandle& pnh,
-                const std::string& skill_name );
+                const ros::NodeHandle& pnh);
 
   bool init();
 

--- a/manipulation_utils/include/manipulation_utils/location.h
+++ b/manipulation_utils/include/manipulation_utils/location.h
@@ -158,7 +158,6 @@ protected:
   std::map<std::string,std::vector<double>> m_lower_bound;
   std::map<std::string,std::vector<double>> m_upper_bound;
 
-
   std::mutex m_scene_mtx; 
   std::map<std::string,LocationPtr> m_locations;
 

--- a/manipulation_utils/include/manipulation_utils/manipulation_utils.h
+++ b/manipulation_utils/include/manipulation_utils/manipulation_utils.h
@@ -36,13 +36,12 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 namespace manipulation 
 {
-
-  /* add a location from the location manager
+  /* add a location to the location manager
   */
   bool addLocation( const ros::NodeHandle& nh,
                     const manipulation_msgs::Location& location);
 
-  /* remove a location from the location manager
+  /* remove a location to the location manager
   */
   bool removeLocation(const ros::NodeHandle& nh,
                       const std::string& location_name);

--- a/manipulation_utils/include/manipulation_utils/pick_objects.h
+++ b/manipulation_utils/include/manipulation_utils/pick_objects.h
@@ -72,8 +72,7 @@ namespace manipulation
   
     public:
       PickObjects(const ros::NodeHandle& nh,
-                  const ros::NodeHandle& pnh,
-                  const std::string& skill_name );
+                  const ros::NodeHandle& pnh);
 
       bool init();
 

--- a/manipulation_utils/include/manipulation_utils/place_objects.h
+++ b/manipulation_utils/include/manipulation_utils/place_objects.h
@@ -69,8 +69,7 @@ namespace manipulation
 
     public:
       PlaceObjects( const ros::NodeHandle& nh,
-                    const ros::NodeHandle& pnh,
-                    const std::string& skill_name);
+                    const ros::NodeHandle& pnh);
   
       bool init();
 

--- a/manipulation_utils/include/manipulation_utils/skill_base.h
+++ b/manipulation_utils/include/manipulation_utils/skill_base.h
@@ -55,7 +55,6 @@ namespace manipulation
       std::map<std::string,double> m_fjt_result;
       
       ros::Publisher m_target_pub;
-      ros::ServiceClient m_job_srv;
       ros::ServiceClient m_set_ctrl_srv;
       
       tf::TransformBroadcaster m_broadcaster;
@@ -73,7 +72,8 @@ namespace manipulation
 
       void fjtClientWaitForResult(const std::string& group_name);
 
-      bool jobExecute(const std::string& tool_id,
+      bool jobExecute(const std::string& job_executor_name,
+                      const std::string& tool_id,
                       const std::string& property_id );
 
       bool setController( const std::string& controller_name );

--- a/manipulation_utils/src/go_to_location.cpp
+++ b/manipulation_utils/src/go_to_location.cpp
@@ -32,11 +32,10 @@ namespace manipulation
 {
 
 GoToLocation::GoToLocation( const ros::NodeHandle& nh, 
-                            const ros::NodeHandle& pnh,
-                            const std::string& skill_name):
+                            const ros::NodeHandle& pnh):
                             m_nh(nh),
                             m_pnh(pnh),
-                            SkillBase(nh,pnh,skill_name)
+                            SkillBase(nh,pnh,"go_to")
 {
   // nothing to do here    
 }
@@ -184,10 +183,10 @@ void GoToLocation::gotoGoalCb(const manipulation_msgs::GoToGoalConstPtr& goal,
     // Set the desired tool behaviour 
     if(!goal->property_exec_id.empty())
     {
-      if (!jobExecute(goal->tool_id,goal->property_exec_id) )
+      if (!jobExecute(goal->job_exec_name,goal->tool_id,goal->property_exec_id) )
       {
         action_res.result = manipulation_msgs::GoToResult::ToolError;
-        ROS_ERROR("Error on service %s result during job execution", m_job_srv.getService().c_str() );
+        ROS_ERROR("Error during job execution" );
         as->setAborted(action_res,"error on service JobExecution result.");
         return;
       }

--- a/manipulation_utils/src/pick_objects.cpp
+++ b/manipulation_utils/src/pick_objects.cpp
@@ -37,11 +37,10 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 namespace manipulation
 {
   PickObjects::PickObjects( const ros::NodeHandle& nh, 
-                            const ros::NodeHandle& pnh,
-                            const std::string& skill_name):
+                            const ros::NodeHandle& pnh):
                             m_nh(nh),
                             m_pnh(pnh),
-                            SkillBase(nh,pnh,skill_name)
+                            SkillBase(nh,pnh,"pick")
   {
     // nothing to do here     
   }
@@ -433,10 +432,10 @@ namespace manipulation
       // Set the desired tool behaviour 
       if(!goal->property_pre_exec_id.empty())
       {
-        if (!jobExecute(goal->tool_id,goal->property_pre_exec_id) )
+        if (!jobExecute(goal->job_exec_name,goal->tool_id,goal->property_pre_exec_id) )
         {
           action_res.result = manipulation_msgs::PickObjectsResult::GraspFailure;
-          ROS_ERROR("Error on service %s during job pre execution", m_job_srv.getService().c_str());
+          ROS_ERROR("Error during job pre execution");
           as->setAborted(action_res,"error on service JobExecution result");
           return;
         }
@@ -602,11 +601,10 @@ namespace manipulation
       // Set the desired tool behaviour 
       if(!goal->property_exec_id.empty())
       {
-        if (!jobExecute(goal->tool_id,goal->property_exec_id) )
+        if (!jobExecute(goal->job_exec_name,goal->tool_id,goal->property_exec_id) )
         {
           action_res.result = manipulation_msgs::PickObjectsResult::GraspFailure;
-          ROS_ERROR("Error on service %s result for object name %s during job execution", m_job_srv.getService().c_str(),
-                                                                                          best_object_name.c_str() );
+          ROS_ERROR("Error during job execution for object name %s ", best_object_name.c_str() );
           as->setAborted(action_res,"error on service JobExecution result");
           return;
         }
@@ -697,11 +695,10 @@ namespace manipulation
       // Set the desired tool behaviour 
       if(!goal->property_post_exec_id.empty())
       {
-        if (!jobExecute(goal->tool_id,goal->property_post_exec_id) )
+        if (!jobExecute(goal->job_exec_name,goal->tool_id,goal->property_post_exec_id) )
         {
           action_res.result = manipulation_msgs::PickObjectsResult::GraspFailure;
-          ROS_ERROR("Error on service %s result for object name %s during job post execution",  m_job_srv.getService().c_str(),
-                                                                                                best_object_name.c_str() );
+          ROS_ERROR("Error during job post execution for object name %s", best_object_name.c_str() );
           as->setAborted(action_res,"error on service JobExecution result");
           return;
         }

--- a/manipulation_utils/src/place_objects.cpp
+++ b/manipulation_utils/src/place_objects.cpp
@@ -38,11 +38,10 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 namespace manipulation
 {
   PlaceObjects::PlaceObjects( const ros::NodeHandle& nh, 
-                              const ros::NodeHandle& pnh,
-                              const std::string& skill_name):
+                              const ros::NodeHandle& pnh):
                               m_nh(nh),
                               m_pnh(pnh),
-                              SkillBase(nh,pnh,skill_name)
+                              SkillBase(nh,pnh,"place")
   {
 
   }
@@ -428,11 +427,10 @@ namespace manipulation
       // Set the desired tool behaviour 
       if(!goal->property_pre_exec_id.empty())
       {
-        if (!jobExecute(goal->tool_id,goal->property_pre_exec_id) )
+        if (!jobExecute(goal->job_exec_name,goal->tool_id,goal->property_pre_exec_id) )
         {
           action_res.result = manipulation_msgs::PlaceObjectsResult::ReleaseError;
-          ROS_ERROR("Error on service %s result for object name %s during job pre execution", m_job_srv.getService().c_str(),
-                                                                                              goal->object_name.c_str());
+          ROS_ERROR("Error on service during job pre execution for object name %s ", goal->object_name.c_str());
           as->setAborted(action_res,"error on service JobExecution result");
           return;
         }
@@ -556,11 +554,10 @@ namespace manipulation
       // Set the desired tool behaviour 
       if(!goal->property_exec_id.empty())
       {
-        if (!jobExecute(goal->tool_id,goal->property_exec_id) )
+        if (!jobExecute(goal->job_exec_name,goal->tool_id,goal->property_exec_id) )
         {
           action_res.result = manipulation_msgs::PlaceObjectsResult::ReleaseError;
-          ROS_ERROR("Error on service %s result for object name %s during job execution", m_job_srv.getService().c_str(),
-                                                                                          goal->object_name.c_str());
+          ROS_ERROR("Error on service during job execution for object name %s ", goal->object_name.c_str());
           as->setAborted(action_res,"error on service JobExecution result");
           return;
         }
@@ -647,11 +644,10 @@ namespace manipulation
       // Set the desired tool behaviour 
       if(!goal->property_post_exec_id.empty())
       {
-        if (!jobExecute(goal->tool_id,goal->property_post_exec_id) )
+        if (!jobExecute(goal->job_exec_name,goal->tool_id,goal->property_post_exec_id) )
         {
           action_res.result = manipulation_msgs::PlaceObjectsResult::ReleaseError;
-          ROS_ERROR("Error on service %s result for object name %s during job post execution",m_job_srv.getService().c_str(),
-                                                                                              goal->object_name.c_str());
+          ROS_ERROR("Error on service during job post execution for object name %s ", goal->object_name.c_str());
           as->setAborted(action_res,"error on service JobExecution result");
           return;
         }

--- a/manipulation_utils/src/skill_base.cpp
+++ b/manipulation_utils/src/skill_base.cpp
@@ -67,9 +67,6 @@ namespace manipulation
      
     m_target_pub = m_nh.advertise<geometry_msgs::PoseStamped>("target_visualization",1);
 
-    m_job_srv = m_pnh.serviceClient<manipulation_msgs::JobExecution>("job/"+m_skill_name); 
-    m_job_srv.waitForExistence();
-
     m_set_ctrl_srv = m_pnh.serviceClient<configuration_msgs::StartConfiguration>("/configuration_manager/start_configuration"); 
     m_set_ctrl_srv.waitForExistence();
 
@@ -152,17 +149,21 @@ namespace manipulation
      m_fjt_clients.at(group_name)->waitForResult();
   }
 
-  bool SkillBase::jobExecute( const std::string& tool_id,
+  bool SkillBase::jobExecute( const std::string& job_executor_name,
+                              const std::string& tool_id,
                               const std::string& property_id  )
   {
+    ros::ServiceClient job_srv = m_pnh.serviceClient<manipulation_msgs::JobExecution>("job/"+job_executor_name); 
+    job_srv.waitForExistence();
+
     manipulation_msgs::JobExecution job_req;
     job_req.request.skill_name = m_skill_name;
     job_req.request.tool_id = tool_id;
     job_req.request.property_id = property_id;
 
-    if (!m_job_srv.call(job_req))
+    if (!job_srv.call(job_req))
     {
-      ROS_ERROR("Unable to call %s service during job execution of skill %s",m_job_srv.getService().c_str(), m_skill_name.c_str());
+      ROS_ERROR("Unable to call %s service during job execution of skill %s",job_srv.getService().c_str(), job_executor_name.c_str());
       return false;
     }
 

--- a/outbound_place/src/outbound_place_client_node.cpp
+++ b/outbound_place/src/outbound_place_client_node.cpp
@@ -69,6 +69,7 @@ int main(int argc, char **argv)
   place_goal.slots_group_names.push_back("group_A");
 
   place_goal.to_loc_ctrl_id = "trajectory_tracking";
+  place_goal.job_exec_name = "place";
   place_goal.tool_id = "fake_gripper";
   place_goal.property_exec_id = "open";
 

--- a/outbound_place/src/outbound_place_server_node.cpp
+++ b/outbound_place/src/outbound_place_server_node.cpp
@@ -40,7 +40,7 @@ int main(int argc, char **argv)
   spinner.start();
 
   ROS_INFO("Creating PlaceOject server...");
-  manipulation::PlaceObjects place(nh,pnh,"place");
+  manipulation::PlaceObjects place(nh,pnh);
 
   ros::ServiceClient ps_client = nh.serviceClient<moveit_msgs::GetPlanningScene>("/get_planning_scene");
   ps_client.waitForExistence();


### PR DESCRIPTION
@marco-faroni @MichiDelle @ManuelBeschi now you can provide the name of the job executor through the Action, so a single object Pick, Place, GoTo can handle multiple job executors without creating a dedicated Pick, Place, GoTo object for every job executor that you need.